### PR TITLE
Fix: compare date-time strings not as string but dates and allow trailing zeros

### DIFF
--- a/src/Shouldly.Json/JsonHelper.cs
+++ b/src/Shouldly.Json/JsonHelper.cs
@@ -18,21 +18,28 @@ internal static class JsonHelper
         {
             (JsonObject actualObj, JsonObject expectedObj) => IsJsonObjectSubtree(actualObj, expectedObj),
             (JsonArray actualArr, JsonArray expectedArr) => IsJsonArraySubtree(actualArr, expectedArr),
-            (JsonValue actualVal, JsonValue expectedVal) =>
-            {
-                if (actualVal.GetValueKind() == JsonValueKind.String
-                    && expectedVal.GetValueKind() == JsonValueKind.String
-                    && actualVal.TryGetValue<DateTimeOffset>(out var actualDate)
-                    && expectedVal.TryGetValue<DateTimeOffset>(out var expectedDate))
-                {
-                    return actualDate == expectedDate;
-                }
-                
-                return actualVal.IsEquivalentTo(expectedVal);
-            },
+            (JsonValue actualVal, JsonValue expectedVal) => TryParseAsDates(actualVal, expectedVal, out var actualDate, out var expectedDate)
+                ? actualDate == expectedDate
+                : actualVal.IsEquivalentTo(expectedVal),
 
             _ => false,
         };
+    }
+
+    private static bool TryParseAsDates(JsonValue actualVal, JsonValue expectedVal, out DateTimeOffset actualDate, out DateTimeOffset expectedDate)
+    {
+        if (actualVal.GetValueKind() == JsonValueKind.String
+            && expectedVal.GetValueKind() == JsonValueKind.String
+            && actualVal.TryGetValue<DateTimeOffset>(out actualDate)
+            && expectedVal.TryGetValue<DateTimeOffset>(out expectedDate))
+        {
+            return true;
+        }
+
+        actualDate = default;
+        expectedDate = default;
+
+        return false;
     }
 
     internal static bool IsJsonObjectSubtree(JsonObject actual, JsonObject expected)

--- a/src/Shouldly.Json/JsonHelper.cs
+++ b/src/Shouldly.Json/JsonHelper.cs
@@ -1,5 +1,6 @@
 namespace Shouldly;
 
+using System;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Json.More;

--- a/src/Shouldly.Json/JsonHelper.cs
+++ b/src/Shouldly.Json/JsonHelper.cs
@@ -18,7 +18,18 @@ internal static class JsonHelper
         {
             (JsonObject actualObj, JsonObject expectedObj) => IsJsonObjectSubtree(actualObj, expectedObj),
             (JsonArray actualArr, JsonArray expectedArr) => IsJsonArraySubtree(actualArr, expectedArr),
-            (JsonValue actualVal, JsonValue expectedVal) => actualVal.IsEquivalentTo(expectedVal),
+            (JsonValue actualVal, JsonValue expectedVal) =>
+            {
+                if (actualVal.GetValueKind() == JsonValueKind.String
+                    && expectedVal.GetValueKind() == JsonValueKind.String
+                    && actualVal.TryGetValue<DateTimeOffset>(out var actualDate)
+                    && expectedVal.TryGetValue<DateTimeOffset>(out var expectedDate))
+                {
+                    return actualDate == expectedDate;
+                }
+                
+                return actualVal.IsEquivalentTo(expectedVal);
+            },
 
             _ => false,
         };

--- a/tests/Shouldly.Json.Tests/ShouldHaveJsonSubtreeTest.cs
+++ b/tests/Shouldly.Json.Tests/ShouldHaveJsonSubtreeTest.cs
@@ -5,8 +5,8 @@ public class ShouldHaveJsonSubtreeTest
     [Fact]
     public void SimpleObject_WhenSubset_ShouldNotThrow()
     {
-        var subset = @"{""name"": ""John""}";
-        var fullSet = @"{""name"": ""John"", ""age"": 30}";
+        var subset = @"{""name"": ""John"", ""createdAt"": ""2025-06-26T10:48:32.3127234+02:00""}";
+        var fullSet = @"{""name"": ""John"", ""age"": 30, ""createdAt"": ""2025-06-26T10:48:32.3127234+02:00""}";
 
         fullSet.ShouldHaveJsonSubtree(subset);
     }
@@ -14,12 +14,21 @@ public class ShouldHaveJsonSubtreeTest
     [Fact]
     public void SimpleObject_WhenNotSubset_ShouldThrow()
     {
-        var subset = @"{""name"": ""John"", ""age"": 31}";
-        var fullSet = @"{""name"": ""John"", ""age"": 30}";
+        var subset = @"{""name"": ""John"", ""age"": 31, ""createdAt"": ""2025-06-26T10:48:32.3127234+02:00""}";
+        var fullSet = @"{""name"": ""John"", ""age"": 30, ""createdAt"": ""2025-06-26T10:48:32.3127234+02:00""}";
 
         Should.Throw<ShouldAssertException>(() => fullSet.ShouldHaveJsonSubtree(subset));
     }
 
+    [Fact]
+    public void SimpleObject_WhenDateFormatDifferentButDateIsSame_ShouldNotThrow()
+    {
+        var subset = @"{""createdAt"": ""2025-06-26T10:48:32.3127230+02:00""}";
+        var fullSet = @"{""createdAt"": ""2025-06-26T10:48:32.312723+02:00""}";
+
+        fullSet.ShouldHaveJsonSubtree(subset);
+    }
+    
     [Fact]
     public void NestedObject_WhenSubset_ShouldNotThrow()
     {


### PR DESCRIPTION
There is currently an issue with comparison of date-time fields where trailing fractional zeros let the comparison fail. This however, should not happen.

Example that fails comparison:
```csharp
var expectedJson = @"{""date"": ""2025-06-26 10:14:23.3781290+02:00""}";
var actualJson = @"{""date"": ""2025-06-26 10:14:23.378129+02:00""}";

expectedJson.ShouldHaveJsonSubstree(actualJson); // fails
```